### PR TITLE
Allow hot reload and install package.json deps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
   frontend:
     build: ./web-frontend
     volumes:
-      - ./web-frontend:/app # hot reload
+      - './web-frontend:/app' # hot reload
+      - '/app/node_modules'
     environment:
       - CHOKIDAR_USEPOLLING=true # hot reload
     ports:

--- a/web-frontend/Dockerfile
+++ b/web-frontend/Dockerfile
@@ -4,13 +4,13 @@ FROM node:lts-alpine
 WORKDIR /app
 
 # copy both 'package.json' and 'package-lock.json' (if available)
-#COPY package*.json ./
+COPY package*.json ./
 
 # install project dependencies
 RUN yarn install
 
 # copy project files and folders to the current working directory (i.e. 'app' folder)
-# COPY . .
+COPY . .
 
 EXPOSE 8080
 CMD [ "yarn", "serve" ]


### PR DESCRIPTION
Previously, we relied on state from the host `node_modules` to be built
before running `docker-compose up`

Now, we set the volume for node_modules so that it is not overwritten
by the volume mounted in the container from the host.

Ref:
- Stackoverflow #59224130