### PR TITLE
[backend] Adding a keyword filter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
       - "PROXY=http://backend:8081"
     ports:
       - "8080:8080"
+    depends_on:
+      - backend
+      - mongo
+      - mongo-express
 
   # backend (API + Metrics)
   backend:
@@ -23,6 +27,7 @@ services:
     environment:
       - "GITHUB_TOKEN=$GITHUB_TOKEN" # an optional PAT for Github
       - "CARGO_HOME=/cargo" # used with a volume to persist cargo stuff
+      - "RETAIN_ALL=$RETAIN_ALL" # to disable parsing of the commit and changelog messages
       - "RUST_BACKTRACE=1"
       - "RUST_LOG=info"
       - "ROCKET_ADDRESS=0.0.0.0"

--- a/web-backend/metrics/src/common/dependabot.rs
+++ b/web-backend/metrics/src/common/dependabot.rs
@@ -48,8 +48,68 @@ pub async fn get_update_metadata(
         );
     }
 
-    serde_json::from_slice(&output.stdout).map_err(|e| {
+    let data = serde_json::from_slice(&output.stdout).map_err(|e| {
         error!("{}", String::from_utf8_lossy(&output.stdout));
         anyhow::Error::msg(e)
-    })
+    });
+
+    parse_texts(data)
+}
+
+// parse_texts will parse the commits and the changelog in order to retain only these where certain
+// words are mentioned that could indicate a security issue. We discard the rest of the data in
+// order to reduce the database size.
+fn parse_texts(input: Result<UpdateMetadata>) -> Result<UpdateMetadata> {
+    if input.is_err() {
+        return input;
+    }
+    if std::env::var("RETAIN_ALL").is_ok() &&  std::env::var("RETAIN_ALL").unwrap() != ""  {
+        println!("DISABLED TEXT PARSING, RETAINING ALL DATA. $RETAIN_ALL={}", std::env::var("RETAIN_ALL").unwrap());
+        return input;
+    }
+
+    let mut data = input.unwrap();
+    match data.changelog_text.as_mut() {
+        Some(text) => if !flagged_text(text) {
+            *text = "".to_string();
+        },
+        None => {}
+    }
+
+     /*
+     // This is if we want to retain all commits, deleting the uninteresting messages only
+     for commit in data.commits.iter_mut(){
+        if flagged_text(&commit.message) {
+            println!("FLAGGED COMMIT!: {}", commit.message);
+        } else {
+            commit.message = "".to_string();
+        }
+    }
+    */
+
+    // This removes completely the commits that are deemed uninteresting
+    data.commits.retain(|x| flagged_text(&x.message));
+
+    Ok(data)
+}
+
+const FLAGGED_WORDS: &'static [&'static str] = &["bug", "secur", "critical",
+                                                "crash", "seed", "key", "malicious",
+                                                "overflow", "underflow", "sec",
+                                                "severity", "sev", "unsafe",
+                                                "secret", "hash", "encrypt",
+                                                "exploit","attack", "defense",
+                                                "vuln","dos","denial", "rce",
+                                                "code exec", "CVE", "advisory",
+                                                "hack", "crack", "brute", "harden",
+                                                "injection", "hijack", "elevation",
+                                                "privilege"];
+
+fn flagged_text(text: &String) -> bool {
+    for word in FLAGGED_WORDS {
+        if text.contains(word) {
+            return true;
+        }
+    }
+    return false;
 }


### PR DESCRIPTION
This is meant to reduce the size of the DB and avoid saving all commits and changelogs:
```
- without this:
Database Stats
Collections (incl. system.namespaces) 	2
Data Size 	975 KB
Storage Size 	524 KB
Avg Obj Size # 	244 KB
Objects # 	4
Indexes # 	2
Index Size 	73.7 KB

- with this:
Database Stats
Collections (incl. system.namespaces) 	2
Data Size 	562 KB
Storage Size 	279 KB
Avg Obj Size # 	281 KB
Objects # 	2
Indexes # 	2
Index Size 	41.0 KB

```

Fixes #33 