### PR TITLE
[frontend] Update rendering of risk items in Reviews View

### DIFF
--- a/web-frontend/src/components/Review.vue
+++ b/web-frontend/src/components/Review.vue
@@ -7,7 +7,7 @@
       <h3>Risk</h3>
       <ul>
         <li v-for="reason in dependency.risk_reasons" :key="reason">
-          {{ reason }}
+          <p v-html=reason></p>
         </li>
       </ul>
     </section>

--- a/web-frontend/src/engines/risk.js
+++ b/web-frontend/src/engines/risk.js
@@ -4,7 +4,7 @@ export function calculate_risk_score(dep) {
 
   if (dep.update.build_rs) {
     risk_score += 10;
-    risk_reasons.push("<code>build.rs</code> file Changed");
+    risk_reasons.push("<code>build.rs</code> file changed");
   }
 
   return { risk_score, risk_reasons };


### PR DESCRIPTION
Rendering was not working correctly for identified risk items after
recent changes.

This commit updates the rendering to use
[rawHTML](https://vuejs.org/v2/guide/syntax.html#Raw-HTML) instead of
the default mustache strings.

Before Fix:
![image](https://user-images.githubusercontent.com/6826729/112530602-dfbe4700-8d63-11eb-85df-92e261a803a7.png)

After Fix:
![image](https://user-images.githubusercontent.com/6826729/112530566-d1702b00-8d63-11eb-9d5f-06e6010b2b95.png)
