### PR TITLE
Add crates.io metrics to analysis crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "crates_io_api",
  "futures",
  "git2",
  "guppy",
@@ -330,6 +331,23 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smartstring",
+]
+
+[[package]]
+name = "crates_io_api"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20576e0ee48ae3dce12672d2a15bdfe7ed9d0e985ab2be7b6586d1b70b7cff73"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -27,3 +27,4 @@ target-spec = "0.7.0" # guppy stuff
 semver = "0.11.0" # semver of dependencies
 octocrab = "0.8.11"  # interact with github API
 rustsec = "0.22.2" # RUSTSEC advisory stuff
+crates_io_api = "0.7.1" #crates.io stuff

--- a/analysis/resources/.gitignore
+++ b/analysis/resources/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/analysis/resources/test/valid_dep/Cargo.toml
+++ b/analysis/resources/test/valid_dep/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "valid_dep"
+version = "0.1.0"
+authors = ["Nasif Imtiaz <nasifimtiaz@fb.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libc = "0.2.97"
+
+[workspace]

--- a/analysis/resources/test/valid_dep/src/main.rs
+++ b/analysis/resources/test/valid_dep/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/analysis/src/cratesio.rs
+++ b/analysis/src/cratesio.rs
@@ -1,0 +1,67 @@
+//! This module abstracts the communication with crates.io for a given crate
+//! Returns Error if the crate is not hosted on crates_io
+
+// TODO: A cheaper way to interact with crates.io can be working with their
+// experimental database dump that is updated daily, https://crates.io/data-access,
+// which will enable us to avoid making http requests and dealing with rate limits
+
+use anyhow::Result;
+use crates_io_api::SyncClient;
+use guppy::graph::PackageMetadata;
+use tabled::Tabled;
+
+#[derive(Tabled, Default)]
+pub struct CratesioReport {
+    pub name: String,
+    pub is_hosted: bool,
+    pub downloads: u64,
+    pub dependents: u64,
+}
+
+pub struct CratesioAnalyzer {
+    client: SyncClient,
+}
+
+impl CratesioAnalyzer {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            client: SyncClient::new(
+                "User-Agent: Whackadep (https://github.com/diem/whackadep)",
+                std::time::Duration::from_millis(1000),
+            )?,
+        })
+    }
+
+    pub fn analyze_cratesio(self, package: &PackageMetadata) -> Result<CratesioReport> {
+        let name = package.name();
+        let is_hosted = package.source().is_crates_io();
+        self.get_cratesio_metrics(name, is_hosted)
+    }
+
+    pub fn get_cratesio_metrics(self, name: &str, is_hosted: bool) -> Result<CratesioReport> {
+        if !is_hosted {
+            return Ok(CratesioReport {
+                name: name.to_string(),
+                is_hosted,
+                ..Default::default()
+            });
+        }
+
+        let crate_info = self.client.get_crate(name)?.crate_data;
+
+        // TODO: crates_io_api makes unnecessary request to page through all dependents,
+        // therefore, taking a long time
+        // when the total count is actually present in each result page
+        // make a PR to the upstream crate? or write custom http request by ourselves?
+        let dependents = self.client.crate_reverse_dependencies(name)?.meta.total;
+
+        let cratesio_report = CratesioReport {
+            name: name.to_string(),
+            is_hosted,
+            downloads: crate_info.downloads,
+            dependents,
+        };
+
+        Ok(cratesio_report)
+    }
+}

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -1,26 +1,39 @@
 //! This crate contains a number of analyses that can be run on dependencies
 
+use anyhow::Result;
 use guppy::graph::PackageMetadata;
 use tabled::Tabled;
+
+mod cratesio;
 
 #[derive(Tabled)]
 pub struct DependencyReport<'a> {
     pub name: &'a str,
     pub has_build_script: bool,
+    pub hosted_on_cratesio: bool,
+    pub cratesio_downloads: u64,
+    pub cratesio_dependents: u64,
 }
 
 pub struct DependencyAnalyzer;
 
 impl DependencyAnalyzer {
-    pub fn analyze_dep<'a>(&self, package: &PackageMetadata<'a>) -> DependencyReport<'a> {
+    pub fn analyze_dep<'a>(&self, package: &PackageMetadata<'a>) -> Result<DependencyReport<'a>> {
         let name = package.name();
         let has_build_script = package.has_build_script();
 
-        // Add more analyses here
+        // Crates.io analysis
+        let cratesio_report = cratesio::CratesioAnalyzer::new()?;
+        let cratesio_report = cratesio_report.analyze_cratesio(package)?;
 
-        DependencyReport {
+        let dependency_report = DependencyReport {
             name,
             has_build_script,
-        }
+            hosted_on_cratesio: cratesio_report.is_hosted,
+            cratesio_downloads: cratesio_report.downloads,
+            cratesio_dependents: cratesio_report.dependents,
+        };
+
+        Ok(dependency_report)
     }
 }

--- a/analysis/src/main.rs
+++ b/analysis/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> Result<()> {
     let reports: Vec<DependencyReport> = direct_dependencies
         .iter()
         .map(|pkg| DependencyAnalyzer.analyze_dep(pkg))
-        .collect();
+        .collect::<Result<_>>()?;
 
     let table = table!(&reports);
     println!("{}", table);


### PR DESCRIPTION
## Changes made

Created a new module to interact with crates.io . The module takes `guppy::graph::PackageMetadata` as input, therefore, ensuring valid cargo metadata as input. Currently, the module implements two metrics: 
1.  total downloads, 
2. total dependents. 

## Testing

1. Created a test crate with single dependency `libc` to test the module output. 
2. Testing for crates not hosted on crates.io

cc @metajack @xvschneider 