### PR TITLE
Add new module to interact with GitHub API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,5 @@ jobs:
 
       - name: Run tests
         run: cargo test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,6 @@ dependencies = [
  "git2",
  "guppy",
  "guppy-summaries",
- "octocrab",
  "regex",
  "reqwest",
  "rust-crypto",
@@ -48,6 +47,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -25,6 +25,6 @@ guppy = { version = "0.9.0", features = ["summaries"] } # library to analyze dep
 guppy-summaries = "0.4.0" # guppy summaries
 target-spec = "0.7.0" # guppy stuff
 semver = "0.11.0" # semver of dependencies
-octocrab = "0.8.11"  # interact with github API
+url = "2.2.2" # url parsing
 rustsec = "0.22.2" # RUSTSEC advisory stuff
 crates_io_api = "0.7.1" #crates.io stuff

--- a/analysis/resources/test/valid_dep/Cargo.toml
+++ b/analysis/resources/test/valid_dep/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.97"
+gitlab = "0.1312.0"
+octocrab = "0.9.1"
 
 [workspace]

--- a/analysis/src/github.rs
+++ b/analysis/src/github.rs
@@ -1,0 +1,130 @@
+//! This module abstracts the communication with GitHub API for a given crate
+
+use anyhow::{anyhow, Result};
+use guppy::graph::PackageMetadata;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, USER_AGENT};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use url::Url;
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct RepoStats {
+    pub full_name: Option<String>,
+    pub stargazers_count: u64,
+    pub subscribers_count: u64,
+    pub forks: u64,
+}
+
+pub struct GitHubReport {
+    pub name: String,               // name of the crate
+    pub repository: Option<String>, // repository url
+    pub is_github_repo: bool,
+    pub repo_stats: RepoStats,
+}
+
+impl GitHubReport {
+    fn new(name: String, repository: Option<String>) -> Self {
+        //Returns a default GitHubReport with is_github_repo set as false
+        GitHubReport {
+            name,
+            repository,
+            is_github_repo: false,
+            repo_stats: RepoStats {
+                full_name: None,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+pub struct GitHubAnalyzer {
+    client: reqwest::blocking::Client,
+}
+
+impl GitHubAnalyzer {
+    fn construct_headers() -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, HeaderValue::from_static("diem/whackadep"));
+
+        let pat = std::env::var("GITHUB_TOKEN")?;
+        let pat = format!("token {}", pat);
+        let mut auth_value = HeaderValue::from_str(&pat)?;
+        auth_value.set_sensitive(true);
+        headers.insert(AUTHORIZATION, auth_value);
+
+        Ok(headers)
+    }
+
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            client: reqwest::blocking::Client::builder()
+                .default_headers(Self::construct_headers()?)
+                .build()?,
+        })
+    }
+
+    pub fn analyze_github(self, package: &PackageMetadata) -> Result<GitHubReport> {
+        let name = package.name();
+        let repository = match package.repository().and_then(|r| Url::from_str(r).ok()) {
+            Some(repository) => repository,
+            None => return Ok(GitHubReport::new(name.to_string(), None)),
+        };
+
+        let is_github_repo = Self::is_github_url(&repository);
+        if !is_github_repo {
+            return Ok(GitHubReport::new(
+                name.to_string(),
+                Some(repository.to_string()),
+            ));
+        }
+
+        let repo_fullname = Self::get_github_repo_fullname(&repository)?;
+
+        // Get Overall stats for a given repo
+        let repo_stats = self.get_github_repo_stats(&repo_fullname)?;
+
+        return Ok(GitHubReport {
+            name: name.to_string(),
+            repository: Some(repository.to_string()),
+            is_github_repo,
+            repo_stats,
+        });
+    }
+
+    fn is_github_url(url: &Url) -> bool {
+        url.host_str()
+            .map(|host| host == "github.com")
+            .unwrap_or(false)
+    }
+
+    fn get_github_repo_fullname(repo_url: &Url) -> Result<String> {
+        assert_eq!(
+            Self::is_github_url(repo_url),
+            true,
+            "Repository is not from GitHub"
+        );
+
+        let mut segments = repo_url.path_segments().unwrap();
+        let owner = segments
+            .next()
+            .ok_or_else(|| anyhow!("repository url missing owner"))?;
+        let repo = segments
+            .next()
+            .map(|repo| repo.trim_end_matches(".git"))
+            .ok_or_else(|| anyhow!("repository url missing repo"))?;
+        return Ok(format!("{}/{}", owner, repo));
+    }
+
+    fn get_github_repo_stats(&self, repo_fullname: &String) -> Result<RepoStats> {
+        let api_endpoint = format!("https://api.github.com/repos/{}", repo_fullname);
+        let response = self.client.get(api_endpoint).send()?;
+
+        if !response.status().is_success() {
+            println!("repo_url: {}", repo_fullname);
+            println!("{:?}", response.text());
+            panic!("http request to GitHub failed");
+        }
+
+        Ok(response.json()?)
+    }
+}

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -5,6 +5,7 @@ use guppy::graph::PackageMetadata;
 use tabled::Tabled;
 
 mod cratesio;
+mod github;
 
 #[derive(Tabled)]
 pub struct DependencyReport<'a> {
@@ -13,6 +14,10 @@ pub struct DependencyReport<'a> {
     pub hosted_on_cratesio: bool,
     pub cratesio_downloads: u64,
     pub cratesio_dependents: u64,
+    pub hosted_on_github: bool,
+    pub github_stars: u64,
+    pub github_subscribers: u64,
+    pub github_forks: u64,
 }
 
 pub struct DependencyAnalyzer;
@@ -26,12 +31,20 @@ impl DependencyAnalyzer {
         let cratesio_report = cratesio::CratesioAnalyzer::new()?;
         let cratesio_report = cratesio_report.analyze_cratesio(package)?;
 
+        // GitHub API analysis
+        let github_report = github::GitHubAnalyzer::new()?;
+        let github_report = github_report.analyze_github(package)?;
+
         let dependency_report = DependencyReport {
             name,
             has_build_script,
             hosted_on_cratesio: cratesio_report.is_hosted,
             cratesio_downloads: cratesio_report.downloads,
             cratesio_dependents: cratesio_report.dependents,
+            hosted_on_github: github_report.is_github_repo,
+            github_stars: github_report.repo_stats.stargazers_count,
+            github_subscribers: github_report.repo_stats.subscribers_count,
+            github_forks: github_report.repo_stats.forks,
         };
 
         Ok(dependency_report)


### PR DESCRIPTION
## Changes made

1. Add new module to interact with GitHub API
2. Implemented methods to get repo stats (star count) but can be easily extended to other analysis

## Tests

2 tests for a package hosted on GitHub and a package not hosted on GitHub. 