### PR TITLE
Add activity metrics to GitHub report

### DIFF
--- a/analysis/src/github.rs
+++ b/analysis/src/github.rs
@@ -242,6 +242,14 @@ impl GitHubAnalyzer {
             return Err(anyhow!("http request to GitHub failed, {:?}", response));
         }
         let response: Vec<CommitInfo> = response.json()?;
+        if response.is_empty() {
+            // At lease one commit should be there
+            return Err(anyhow!(
+                "No commit found for {}, {:?}",
+                repo_fullname,
+                response
+            ));
+        }
 
         let last_commit = &response[0];
         let last_commit_date = last_commit.commit.committer.date;

--- a/analysis/src/github.rs
+++ b/analysis/src/github.rs
@@ -1,18 +1,36 @@
 //! This module abstracts the communication with GitHub API for a given crate
 
 use anyhow::{anyhow, Result};
+use chrono::{DateTime, Duration, FixedOffset, Utc};
 use guppy::graph::PackageMetadata;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, USER_AGENT};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use url::Url;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
-pub struct RepoStats {
-    pub full_name: Option<String>,
-    pub stargazers_count: u64,
-    pub subscribers_count: u64,
-    pub forks: u64,
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CommitInfo {
+    pub sha: String,
+    pub commit: Commit,
+    pub author: Option<User>,
+    pub committer: Option<User>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Commit {
+    pub author: Date,
+    pub committer: Date,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Date {
+    pub date: DateTime<FixedOffset>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct User {
+    // can be null if the user is not registered on GitHub
+    pub login: Option<String>,
 }
 
 pub struct GitHubReport {
@@ -20,6 +38,21 @@ pub struct GitHubReport {
     pub repository: Option<String>, // repository url
     pub is_github_repo: bool,
     pub repo_stats: RepoStats,
+    pub activity_metrics: ActivityMetrics,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct RepoStats {
+    pub full_name: Option<String>,
+    pub default_branch: Option<String>,
+    pub stargazers_count: u64,
+    pub subscribers_count: u64,
+    pub forks: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct ActivityMetrics {
+    pub days_since_last_commit: u64,
 }
 
 impl GitHubReport {
@@ -31,6 +64,10 @@ impl GitHubReport {
             is_github_repo: false,
             repo_stats: RepoStats {
                 full_name: None,
+                default_branch: None,
+                ..Default::default()
+            },
+            activity_metrics: ActivityMetrics {
                 ..Default::default()
             },
         }
@@ -83,11 +120,22 @@ impl GitHubAnalyzer {
         // Get Overall stats for a given repo
         let repo_stats = self.get_github_repo_stats(&repo_fullname)?;
 
+        // Get the default branch
+        let default_branch = repo_stats.default_branch.clone();
+        let default_branch = match default_branch {
+            Some(branch) => branch,
+            None => return Err(anyhow!("No default branch found for package repository")),
+        };
+
+        // Get recent activity metrics
+        let activity_metrics = self.get_activity_metrics(&repo_fullname, &default_branch)?;
+
         return Ok(GitHubReport {
             name: name.to_string(),
             repository: Some(repository.to_string()),
             is_github_repo,
             repo_stats,
+            activity_metrics,
         });
     }
 
@@ -127,6 +175,48 @@ impl GitHubAnalyzer {
 
         Ok(response.json()?)
     }
+
+    fn get_activity_metrics(
+        self,
+        repo_fullname: &String,
+        default_branch: &String,
+    ) -> Result<ActivityMetrics> {
+        let days_since_last_commit = self
+            .get_time_since_last_commit(&repo_fullname, &default_branch)?
+            .num_days() as u64;
+
+        Ok(ActivityMetrics {
+            days_since_last_commit,
+        })
+    }
+
+    fn get_time_since_last_commit(
+        &self,
+        repo_fullname: &String,
+        default_branch: &String,
+    ) -> Result<Duration> {
+        let api_endpoint = format!(
+            "https://api.github.com/repos/{}/commits?sha={}&per_page=1",
+            repo_fullname, default_branch
+        );
+        let response = self.client.get(api_endpoint).send()?;
+
+        if !response.status().is_success() {
+            panic!("http request to GitHub failed, {:?}", response);
+        }
+
+        let response: Vec<CommitInfo> = response.json()?;
+        // at lease one commit must be in the repository
+        assert_eq!(response.is_empty(), false);
+
+        let last_commit = &response[0];
+        let last_commit_date = last_commit.commit.committer.date;
+
+        let utc_now: DateTime<Utc> = Utc::now();
+        let duration = utc_now.signed_duration_since(last_commit_date);
+        assert!(duration.num_days() >= 0);
+        Ok(duration)
+    }
 }
 
 #[cfg(test)]
@@ -146,6 +236,21 @@ mod tests {
             .unwrap()
     }
 
+    fn get_test_repo(package_name: &str) -> (String, String) {
+        let graph = get_test_graph();
+        let pkg = graph.packages().find(|p| p.name() == package_name).unwrap();
+
+        let repository = pkg.repository().unwrap();
+        let url = Url::from_str(repository).unwrap();
+        let fullname = GitHubAnalyzer::get_github_repo_fullname(&url).unwrap();
+
+        let github_analyzer = test_github_analyzer();
+        let report = github_analyzer.analyze_github(&pkg).unwrap();
+        let default_branch = report.repo_stats.default_branch.unwrap();
+
+        (fullname, default_branch)
+    }
+
     #[test]
     fn test_github_stats_for_libc() {
         let github_analyzer = test_github_analyzer();
@@ -155,11 +260,8 @@ mod tests {
         let report = github_analyzer.analyze_github(&pkg).unwrap();
 
         assert_eq!(report.is_github_repo, true);
-        println!(
-            "star count for {} is {}",
-            pkg.name(),
-            report.repo_stats.stargazers_count
-        );
+
+        // Relying on Libc to have at least one star on GitHub
         assert!(report.repo_stats.stargazers_count > 0);
     }
 
@@ -173,5 +275,16 @@ mod tests {
 
         assert_eq!(report.is_github_repo, false);
         assert_eq!(report.repo_stats.stargazers_count, 0);
+    }
+
+    #[test]
+    fn test_github_time_since_last_commit() {
+        let github_analyzer = test_github_analyzer();
+        let (fullname, default_branch) = get_test_repo("octocrab");
+
+        let time_since_last_commit = github_analyzer
+            .get_time_since_last_commit(&fullname, &default_branch)
+            .unwrap();
+        assert_eq!(time_since_last_commit.num_nanoseconds().unwrap() > 0, true)
     }
 }

--- a/analysis/src/github.rs
+++ b/analysis/src/github.rs
@@ -61,7 +61,7 @@ pub struct RepoStats {
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct ActivityMetrics {
-    pub days_since_last_commit: u64,
+    pub days_since_last_commit: u64, // on default branch
     pub days_since_last_open_issue: Option<u64>,
     pub open_issues_labeld_bug: u64,
     pub open_issues_labeled_security: u64,
@@ -70,6 +70,7 @@ pub struct ActivityMetrics {
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct RecentActivity {
+    // On all branches
     pub past_days: u64,
     pub commits: u64,
     pub committers: u64,

--- a/analysis/src/github.rs
+++ b/analysis/src/github.rs
@@ -189,9 +189,7 @@ impl GitHubAnalyzer {
         let response = self.client.get(api_endpoint).send()?;
 
         if !response.status().is_success() {
-            println!("repo_url: {}", repo_fullname);
-            println!("{:?}", response.text());
-            panic!("http request to GitHub failed");
+            return Err(anyhow!("http request to GitHub failed, {:?}", response));
         }
 
         Ok(response.json()?)
@@ -241,7 +239,7 @@ impl GitHubAnalyzer {
         let response = self.client.get(api_endpoint).send()?;
 
         if !response.status().is_success() {
-            panic!("http request to GitHub failed, {:?}", response);
+            return Err(anyhow!("http request to GitHub failed, {:?}", response));
         }
         let response: Vec<CommitInfo> = response.json()?;
 
@@ -262,7 +260,7 @@ impl GitHubAnalyzer {
         let response = self.client.get(api_endpoint).send()?;
 
         if !response.status().is_success() {
-            panic!("http request to GitHub failed, {:?}", response);
+            return Err(anyhow!("http request to GitHub failed, {:?}", response));
         }
 
         let response: Vec<Issue> = response.json()?;
@@ -327,7 +325,7 @@ impl GitHubAnalyzer {
             );
             let response = self.client.get(api_endpoint).send()?;
             if !response.status().is_success() {
-                panic!("http request to GitHub failed, {:?}", response);
+                return Err(anyhow!("http request to GitHub failed, {:?}", response));
             }
 
             let mut response: Vec<CommitInfo> = response.json()?;

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -18,6 +18,14 @@ pub struct DependencyReport<'a> {
     pub github_stars: u64,
     pub github_subscribers: u64,
     pub github_forks: u64,
+    pub open_issues: u64,
+    pub days_since_last_commit_on_default_branch: u64,
+    pub days_since_last_open_issue: u64,
+    pub open_issues_labeld_bug: u64,
+    pub open_issues_labeled_security: u64,
+    pub past_days_for_recent_stats: u64,
+    pub recent_commits: u64,
+    pub recent_committers: u64,
 }
 
 pub struct DependencyAnalyzer;
@@ -45,6 +53,21 @@ impl DependencyAnalyzer {
             github_stars: github_report.repo_stats.stargazers_count,
             github_subscribers: github_report.repo_stats.subscribers_count,
             github_forks: github_report.repo_stats.forks,
+            open_issues: github_report.repo_stats.open_issues,
+            days_since_last_commit_on_default_branch: github_report
+                .activity_metrics
+                .days_since_last_commit,
+            days_since_last_open_issue: github_report
+                .activity_metrics
+                .days_since_last_open_issue
+                .unwrap_or(0),
+            open_issues_labeld_bug: github_report.activity_metrics.open_issues_labeld_bug,
+            open_issues_labeled_security: github_report
+                .activity_metrics
+                .open_issues_labeled_security,
+            past_days_for_recent_stats: github_report.activity_metrics.recent_activity.past_days,
+            recent_commits: github_report.activity_metrics.recent_activity.commits,
+            recent_committers: github_report.activity_metrics.recent_activity.committers,
         };
 
         Ok(dependency_report)


### PR DESCRIPTION
Added analysis on recent activity metrics in GitHub module.

Added metrics:
1. number of days since last commit on default branch
2. number of open issues
3. number of days since last open issue created
4. number of open issues labeled `bug` 
5. number of open issues labeled `security`
6. activity metrics in recent times (six months, can be configured)
  i. # commits
  ii. # contributors
  
 Note: issues here indicate both issues and pull requests. apparently, GitHub API doesn't provide a parameter to filter between them. We'd have to iterate through all open issues and check if it's a PR which is inefficient and may cross rate limits for repositories with large number of open issues with REST API. Also, for our analysis, open issues+PR both signals work potentially needed to be done and therefore makes sense to merge the two.
