### PR TITLE
Add analysis of unsafe code in dependencies through cargo geiger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install cargo-download
         run: cargo install cargo-download
 
+      - name: Install cargo-geiger
+        run: cargo install cargo-geiger
+
       - name: Lint
         run: |
           cargo fmt -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
  "tabled",
  "target-spec",
  "tempfile",
@@ -2570,6 +2571,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1569374bd54623ec8bd592cf22ba6e03c0f177ff55fbc8c29a49e296e7adecf"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -30,3 +30,4 @@ rustsec = "0.22.2" # RUSTSEC advisory stuff
 crates_io_api = "0.7.1" # crates.io stuff
 tokei = "12.1.2" # loc count
 camino = "1.0.4" # UTF-8 path stuff
+serial_test = "0.5.1" # avoiding running some tests in parallel

--- a/analysis/src/code.rs
+++ b/analysis/src/code.rs
@@ -326,6 +326,7 @@ impl CodeAnalyzer {
 mod test {
     use super::*;
     use guppy::{graph::PackageGraph, MetadataCommand};
+    use serial_test::serial;
     use std::path::PathBuf;
 
     fn get_test_graph() -> PackageGraph {
@@ -379,15 +380,21 @@ mod test {
     }
 
     #[test]
+    #[serial]
     fn test_code_analyzer() {
         let code_analyzer = get_test_code_analyzer();
         let graph = get_test_graph();
         let code_reports = code_analyzer.analyze_code(&graph).unwrap();
         println!("{:?}", code_reports);
-        assert!(code_reports.len() > 0)
+
+        assert!(code_reports.len() > 0);
+        let report = &code_reports[0];
+        assert_eq!(report.unsafe_report.is_none(), false);
     }
 
     #[test]
+    #[serial]
+    #[ignore]
     fn test_code_cargo_geiger() {
         let path = PathBuf::from("resources/test/valid_dep/Cargo.toml");
         let geiger_report = CodeAnalyzer::get_cargo_geiger_report(&path).unwrap();
@@ -396,6 +403,8 @@ mod test {
     }
 
     #[test]
+    #[serial]
+    #[ignore]
     fn test_code_geiger_report_for_workspace() {
         let code_analyzer = get_test_code_analyzer();
         let graph = MetadataCommand::new()

--- a/analysis/src/code.rs
+++ b/analysis/src/code.rs
@@ -30,13 +30,13 @@ pub struct DepReport {
 }
 
 pub struct CodeAnalyzer {
-    cache: RefCell<HashMap<String, LOCReport>>,
+    loc_cache: RefCell<HashMap<String, LOCReport>>,
 }
 
 impl CodeAnalyzer {
     pub fn new() -> Self {
         Self {
-            cache: RefCell::new(HashMap::new()),
+            loc_cache: RefCell::new(HashMap::new()),
         }
     }
 
@@ -104,9 +104,9 @@ impl CodeAnalyzer {
             )
         })?;
 
-        if self.cache.borrow().contains_key(manifest_path.as_str()) {
+        if self.loc_cache.borrow().contains_key(manifest_path.as_str()) {
             let code_report = self
-                .cache
+                .loc_cache
                 .borrow()
                 .get(manifest_path.as_str())
                 .ok_or_else(|| anyhow!("Caching error"))?
@@ -133,13 +133,13 @@ impl CodeAnalyzer {
                 .unwrap_or(0),
         };
 
-        // put in cache
-        self.cache
+        // put in loc_cache
+        self.loc_cache
             .borrow_mut()
             .insert(manifest_path.to_string(), loc_report);
 
         let code_report = self
-            .cache
+            .loc_cache
             .borrow()
             .get(manifest_path.as_str())
             .ok_or_else(|| anyhow!("Caching error"))?


### PR DESCRIPTION
## Changes made
Add processing of cargo geiger report for unsafe code

## Improvement TODO 
1. As Cargo geiger cannot run over a virtual manifest and need to run over a package.toml, our code runs cargo geiger over all member packages making it a very expensive and time consuming process. [ Issue reported in the upstream.](https://github.com/rust-secure-code/cargo-geiger/issues/206)