### PR TITLE
Get difference between crates.io hosted code and code in git source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "camino",
  "chrono",
  "crates_io_api",
+ "flate2",
  "futures",
  "git2",
  "guppy",
@@ -45,6 +46,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tabled",
+ "tar",
  "target-spec",
  "tempfile",
  "tokei",
@@ -423,6 +425,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,10 +688,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "filetime"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "flate2"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2847,6 +2882,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
+name = "tar"
+version = "0.4.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-spec"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3678,4 +3724,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
 ]

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -31,3 +31,5 @@ crates_io_api = "0.7.1" # crates.io stuff
 tokei = "12.1.2" # loc count
 camino = "1.0.4" # UTF-8 path stuff
 serial_test = "0.5.1" # avoiding running some tests in parallel
+tar = "0.4.35" # tar file stuff
+flate2 = "1.0.20" # compression/decompression

--- a/analysis/resources/test/valid_dep/Cargo.toml
+++ b/analysis/resources/test/valid_dep/Cargo.toml
@@ -10,5 +10,6 @@ edition = "2018"
 libc = "0.2.97"
 gitlab = "0.1312.0"
 octocrab = "0.9.1"
+guppy = "0.8.0"
 
 [workspace]

--- a/analysis/src/diff.rs
+++ b/analysis/src/diff.rs
@@ -1,0 +1,121 @@
+//! This module abstracts diff analysis between code versions
+
+use anyhow::{anyhow, Result};
+use guppy::graph::PackageMetadata;
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use std::{
+    io::copy,
+    path::{Path, PathBuf},
+};
+use tempfile::{tempdir, TempDir};
+use url::Url;
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct CrateSourceDiffReport {
+    // This type presents information on the difference
+    // between crates.io source code
+    // and git source hosted code
+    // for a given version
+    pub name: String,
+    pub version: String,
+    pub release_commit_found: Option<bool>,
+    pub release_commit_analyzed: Option<bool>,
+    pub is_different: Option<bool>,
+    pub file_diff_stats: Option<FileDiffStats>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct FileDiffStats {
+    pub files_added: u64,
+    pub files_modified: u64,
+    pub files_deleted: u64,
+}
+
+pub struct DiffAnalyzer {
+    dir: TempDir,   // hold temporary code files
+    client: Client, // for downloading files
+}
+
+impl DiffAnalyzer {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            dir: tempdir()?,
+            client: Client::new(),
+        })
+    }
+
+    pub fn analyze_crate_source_diff(
+        self,
+        package: &PackageMetadata,
+    ) -> Result<CrateSourceDiffReport> {
+        let name = package.name().to_string();
+        let version = package.version().to_string();
+        let repository = match package.repository() {
+            Some(repo) => Self::trim_remote_url(repo)?,
+            None => {
+                return Ok(CrateSourceDiffReport {
+                    name,
+                    version,
+                    ..Default::default()
+                });
+            }
+        };
+
+        Ok(CrateSourceDiffReport {
+            ..Default::default()
+        })
+    }
+
+    fn trim_remote_url(url: &str) -> Result<String> {
+        // Trim down remote git urls like GitHub for cloning
+        // in cases where the crate is in a subdirectory of the repo
+        // in the format "host_url/owner/repo"
+        let url = Url::from_str(url)?;
+
+        let host = url.host_str().ok_or_else(|| anyhow!("invalid host"))?;
+        // TODO: check if host is from recognized sources, e.g. github, bitbucket, gitlab
+
+        let mut segments = url
+            .path_segments()
+            .ok_or_else(|| anyhow!("error parsing url"))?;
+        let owner = segments
+            .next()
+            .ok_or_else(|| anyhow!("repository url missing owner"))?;
+        let repo = segments
+            .next()
+            .map(|repo| repo.trim_end_matches(".git"))
+            .ok_or_else(|| anyhow!("repository url missing repo"))?;
+
+        let url = format!("https://{}/{}/{}", host, owner, repo);
+        return Ok(url);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use guppy::{graph::PackageGraph, MetadataCommand};
+
+    fn get_test_diff_analyzer() -> DiffAnalyzer {
+        DiffAnalyzer::new().unwrap()
+    }
+
+    fn get_test_graph() -> PackageGraph {
+        MetadataCommand::new()
+            .current_dir(PathBuf::from("resources/test/valid_dep"))
+            .build_graph()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_diff_trim_git_url() {
+        let url = "https://github.com/facebookincubator/cargo-guppy/tree/main/guppy";
+        let trimmed_url = DiffAnalyzer::trim_remote_url(url).unwrap();
+        assert_eq!(
+            trimmed_url,
+            "https://github.com/facebookincubator/cargo-guppy"
+        );
+    }
+}

--- a/analysis/src/diff.rs
+++ b/analysis/src/diff.rs
@@ -8,9 +8,16 @@ use std::str::FromStr;
 use std::{
     io::copy,
     path::{Path, PathBuf},
+    fs::{read_dir, DirEntry, File},
 };
 use tempfile::{tempdir, TempDir};
 use url::Url;
+use git2::{
+    AutotagOption, Delta, Diff, DiffOptions, Direction, FetchOptions, IndexAddOption, Oid,
+    Repository, Signature, Tree,
+};
+use flate2::read::GzDecoder;
+use tar::Archive;
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct CrateSourceDiffReport {
@@ -63,6 +70,12 @@ impl DiffAnalyzer {
             }
         };
 
+        //Setup a git repository for crates.io hosted source code
+        let crate_source_path = self.get_cratesio_version(&name, &version)?;
+
+        // Get commit for the version release in the git source
+        let git_repo = self.get_git_repo(&name, &repository)?;
+
         Ok(CrateSourceDiffReport {
             ..Default::default()
         })
@@ -91,6 +104,62 @@ impl DiffAnalyzer {
         let url = format!("https://{}/{}/{}", host, owner, repo);
         return Ok(url);
     }
+
+    fn get_cratesio_version(&self, name: &str, version: &str) -> Result<PathBuf> {
+        let download_path = format!(
+            "https://crates.io/api/v1/crates/{}/{}/download",
+            name, version
+        );
+        let dest_file = format!("{}-{}-cratesio", name, version);
+        Ok(self.download_file(&download_path, &dest_file)?)
+    }
+
+    fn get_git_repo(&self, name: &str, url: &str) -> Result<Repository> {
+        let dest_file = format!("{}-source", name);
+        let dest_path = self.dir.path().join(&dest_file);
+        let repo = Repository::clone(url, dest_path)?;
+        Ok(repo)
+    }
+
+    fn download_file(&self, download_path: &str, dest_file: &str) -> Result<PathBuf> {
+        // Destination directory to contain downloded files
+        let dest_path = self.dir.path().join(&dest_file);
+
+        // check if destination directory exists, if not proceed
+        if !dest_path.exists() {
+            // First download the file as tar_gz
+            let targz_path = self.dir.path().join(format!("{}.targ.gz", dest_file));
+            let mut targz_file = File::create(&targz_path)?;
+            let mut response = self.client.get(download_path).send()?;
+            copy(&mut response, &mut targz_file)?;
+
+            // Then decompress the file
+            self.decompress_targz(&targz_path, &dest_path)?;
+        }
+
+        // Get the only directory within dest_path where files are unpacked
+        let entries: Vec<DirEntry> = read_dir(dest_path)?
+            .filter_map(|entry| entry.ok())
+            .collect();
+        if entries.len() != 1 {
+            return Err(anyhow!("Error in locating directory for unpacked files"));
+        }
+
+        // Return the directory containing unpacked files
+        Ok(entries[0].path())
+    }
+
+    // note: in some functions, &self is not used,
+    // however the functions may work with tempdirs set up by self,
+    // therefore passing &self to them to make sure self (and, tempdir) still exists
+
+    fn decompress_targz(&self, targz_path: &Path, dest_path: &Path) -> Result<()> {
+        let tar_gz = File::open(targz_path)?;
+        let tar = GzDecoder::new(tar_gz);
+        let mut archive = Archive::new(tar);
+        archive.unpack(dest_path)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -117,5 +186,43 @@ mod test {
             trimmed_url,
             "https://github.com/facebookincubator/cargo-guppy"
         );
+    }
+
+    #[test]
+    fn test_diff_download_file() {
+        let diff_analyzer = get_test_diff_analyzer();
+        let name = "libc";
+        let version = "0.2.97";
+        let path = diff_analyzer
+            .download_file(
+                format!(
+                    "https://crates.io//api/v1/crates/{}/{}/download",
+                    name, version
+                )
+                .as_str(),
+                format!("{}-{}", &name, &version).as_str(),
+            )
+            .unwrap();
+        assert_eq!(path.exists(), true);
+    }
+
+    #[test]
+    fn test_diff_crate_source() {
+        let diff_analyzer = get_test_diff_analyzer();
+        let name = "libc";
+        let version = "0.2.97";
+        let path = diff_analyzer.get_cratesio_version(&name, &version).unwrap();
+        assert_eq!(path.exists(), true);
+    }
+
+    #[test]
+    fn test_diff_git_repo() {
+        let diff_analyzer = get_test_diff_analyzer();
+        let name = "libc";
+        let url = "https://github.com/rust-lang/libc";
+        let repo = diff_analyzer.get_git_repo(&name, url).unwrap();
+        assert_eq!(repo.workdir().is_none(), false);
+        assert_eq!(repo.path().exists(), true);
+        // TODO add tests for non-git repos
     }
 }

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -6,6 +6,7 @@ use tabled::Tabled;
 
 mod code;
 mod cratesio;
+mod diff;
 mod github;
 
 #[derive(Tabled)]
@@ -43,6 +44,9 @@ impl DependencyAnalyzer {
         // GitHub API analysis
         let github_report = github::GitHubAnalyzer::new()?;
         let github_report = github_report.analyze_github(package)?;
+
+        let crate_source_report = diff::DiffAnalyzer::new()?;
+        let crate_source_report = crate_source_report.analyze_crate_source_diff(package)?;
 
         let dependency_report = DependencyReport {
             name,


### PR DESCRIPTION
1. Infer tag in the git repository for a certain version through string matching heuristics
2. Downloads code from crates.io and compare with the tagged version in git source 
3. Determines crates.io and git source are different if there are new files added or files modified in the crates.io than in the git source [ignoring config files] 