### PR TITLE
Diff only the crate sub-directory when analyzing updates

### DIFF
--- a/depdive/src/diff.rs
+++ b/depdive/src/diff.rs
@@ -572,9 +572,9 @@ mod test {
     #[serial]
     fn test_diff_head_commit_oid_for_version() {
         let diff_analyzer = get_test_diff_analyzer();
+        let name = "test-version-tag";
+        let url = "https://github.com/nasifimtiazohi/test-version-tag";
 
-        let name = "tomcat";
-        let url = "https://github.com/apache/tomcat";
         let repo = diff_analyzer.get_git_repo(&name, url).unwrap();
         let oid = diff_analyzer
             .get_head_commit_oid_for_version(&repo, &name, "0.0.8")
@@ -585,36 +585,33 @@ mod test {
             .unwrap();
         assert_eq!(
             oid.unwrap(),
-            Oid::from_str("64520a63e23437b4e92db42bfc70a20d1f9e79c4").unwrap()
+            Oid::from_str("51efd612af12183a682bb3242d41369d2879ad60").unwrap()
         );
         let oid = diff_analyzer
             .get_head_commit_oid_for_version(&repo, &name, "10.0.8-")
             .unwrap();
         assert!(oid.is_none());
 
-        let name = "cargo-guppy";
-        let url = "https://github.com/facebookincubator/cargo-guppy";
-        let repo = diff_analyzer.get_git_repo(&name, url).unwrap();
         let oid = diff_analyzer
             .get_head_commit_oid_for_version(&repo, "hakari", "0.3.0")
             .unwrap();
         assert_eq!(
             oid.unwrap(),
-            Oid::from_str("fe61a8b85feab1963ee1985bf0e4791fdd354aa5").unwrap()
+            Oid::from_str("946ddf053582067b843c19f1270fe92eaa0a7cb3").unwrap()
         );
         let oid = diff_analyzer
             .get_head_commit_oid_for_version(&repo, "guppy", "0.3.0")
             .unwrap();
         assert_eq!(
             oid.unwrap(),
-            Oid::from_str("9fd47f429f7453938279ecbe8b3f1dd077d655fa").unwrap()
+            Oid::from_str("dd7e5609e640f468a7e15a32fe36b607bae13e3e").unwrap()
         );
         let oid = diff_analyzer
             .get_head_commit_oid_for_version(&repo, "guppy-summaries", "0.3.0")
             .unwrap();
         assert_eq!(
             oid.unwrap(),
-            Oid::from_str("7a2c65e6f9fbcd008b240d8574fe7057291caa06").unwrap()
+            Oid::from_str("24e00d39f90baa1daa2ef6f9a2bdb49e581874b3").unwrap()
         );
     }
 

--- a/depdive/src/update.rs
+++ b/depdive/src/update.rs
@@ -679,9 +679,9 @@ mod test {
                     report.updated_version.version,
                     Version::parse("0.9.0").unwrap()
                 );
-                assert_eq!(report.diff_stats.as_ref().unwrap().files_changed, 26);
-                assert_eq!(report.diff_stats.as_ref().unwrap().insertions, 373);
-                assert_eq!(report.diff_stats.as_ref().unwrap().deletions, 335);
+                assert_eq!(report.diff_stats.as_ref().unwrap().files_changed, 6);
+                assert_eq!(report.diff_stats.as_ref().unwrap().insertions, 199);
+                assert_eq!(report.diff_stats.as_ref().unwrap().deletions, 82);
                 assert!(report
                     .diff_stats
                     .as_ref()


### PR DESCRIPTION
for `guppy:0.8.0` to `guppy:0.9.0` [GitHub](https://github.com/facebookincubator/cargo-guppy/compare/guppy-0.8.0...guppy-0.9.0) will tell you 26 files changed when comparing the changes. However, within guppy, only 6 files have changed.

Like [what has been](https://github.com/diem/whackadep/pull/74) in analyzing difference between crate hosted code and git source code, we only measure the diff in the crate specific files while analyzing diff during version updates for a dependency.