### PR TITLE
Generate super toml for virtual manifests to satisfy cargo geiger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
  "git2",
  "guppy",
  "guppy-summaries",
+ "indoc",
  "regex",
  "reqwest",
  "rust-crypto",
@@ -1291,6 +1292,15 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "indoc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+dependencies = [
+ "unindent",
 ]
 
 [[package]]
@@ -3444,6 +3454,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,7 @@ dependencies = [
  "thiserror",
  "tokei",
  "tokio",
+ "toml",
  "tracing",
  "url",
 ]

--- a/depdive/Cargo.toml
+++ b/depdive/Cargo.toml
@@ -14,7 +14,7 @@ reqwest = "0.11.0" # http client
 tempfile = "3.2.0" # temporary folder helper
 serde = { version = "1.0", features = ["derive"] } # bson serialization
 serde_json = "1.0" # bson serialization
-tokio = { version = "1.6.1", features = ["full"] } # old version because of mongodb driver...
+tokio = "1.6.1"
 futures = "0.3.12" # async stuff
 tracing = "0.1.22" # logging
 regex = "1.4.3" # used for checking diff output

--- a/depdive/Cargo.toml
+++ b/depdive/Cargo.toml
@@ -35,3 +35,4 @@ tar = "0.4.35" # tar file stuff
 flate2 = "1.0.20" # compression/decompression
 thiserror = "1.0.26"
 indoc = "1.0.3" # multi-line string stuff
+toml = "0.5.8" # toml parsing

--- a/depdive/Cargo.toml
+++ b/depdive/Cargo.toml
@@ -34,3 +34,4 @@ serial_test = "0.5.1" # avoiding running some tests in parallel
 tar = "0.4.35" # tar file stuff
 flate2 = "1.0.20" # compression/decompression
 thiserror = "1.0.26"
+indoc = "1.0.3" # multi-line string stuff

--- a/depdive/resources/test/valid_dep/Cargo.toml
+++ b/depdive/resources/test/valid_dep/Cargo.toml
@@ -16,5 +16,6 @@ libc = "0.2.97"
 gitlab = "0.1312.0"
 octocrab = "0.9.1"
 guppy = "0.8.0"
+syn = { version = "1.0.73", default_features = false }
 
 [workspace]

--- a/depdive/src/code.rs
+++ b/depdive/src/code.rs
@@ -350,7 +350,7 @@ impl CodeAnalyzer {
         // Else make a super package to replicate the dep graph
         // and run cargo geiger on that package
         let super_package = SuperPackageGenerator::new()?;
-        let _dir = super_package.get_super_package_directory()?;
+        let _dir = super_package.get_super_package_directory(&graph)?;
 
         Ok(())
     }

--- a/depdive/src/lib.rs
+++ b/depdive/src/lib.rs
@@ -12,6 +12,7 @@ mod code;
 mod cratesio;
 mod diff;
 mod github;
+mod super_toml;
 mod update;
 
 // Usage metrics pulled from crates.io API

--- a/depdive/src/super_toml.rs
+++ b/depdive/src/super_toml.rs
@@ -1,0 +1,92 @@
+//! This module abstracts various manipulation with Cargo.toml and Cargo.lock files
+//! 1. It can create a custom package that repicates the full dependency build of a given workspace
+//! TODO: This module can work as a stand-alone crate; isolate and publish
+
+use anyhow::Result;
+use guppy::graph::{PackageGraph, PackageMetadata};
+use indoc::indoc;
+use std::fs::{create_dir_all, File};
+use std::io::Write;
+use tempfile::{tempdir, TempDir};
+
+/// For a given workspace,
+/// This returns a temporary directory of a valid package
+/// that replicates the dependency build of a given workspace
+/// with a Cargo.toml and Cargo.lock file
+pub struct SuperPackageGenerator {
+    dir: TempDir,
+}
+
+impl SuperPackageGenerator {
+    pub fn new() -> Result<Self> {
+        Ok(Self { dir: tempdir()? })
+    }
+
+    pub fn get_super_package_directory(&self) -> Result<&TempDir> {
+        self.setup_empty_package()?;
+        Ok(&self.dir)
+    }
+
+    fn setup_empty_package(&self) -> Result<()> {
+        // Create src directory with main.rs file
+        let src = self.dir.path().join("src");
+        create_dir_all(&src)?;
+        let main = src.join("main.rs");
+        let mut output = File::create(&main)?;
+        write!(output, "fn main() {{}}")?;
+
+        // Create Cargo.toml file
+        let path = self.dir.path().join("Cargo.toml");
+        let mut file = File::create(&path)?;
+        let toml = self.get_header_string();
+        write!(file, "{}", toml).unwrap();
+
+        Ok(())
+    }
+
+    fn get_header_string(&self) -> String {
+        String::from(indoc! {r#"
+                [package]
+                name = "super_toml"
+                version = "0.1.0"
+                edition = "2018"
+
+            "#})
+    }
+}
+
+// TODO: crate a new module `guppy_wrapper`
+// that holds common function like below to be used throughout this crate
+fn get_direct_dependencies(graph: &PackageGraph) -> Vec<PackageMetadata> {
+    graph
+        .query_workspace()
+        .resolve_with_fn(|_, link| {
+            let (from, to) = link.endpoints();
+            from.in_workspace() && !to.in_workspace()
+        })
+        .packages(guppy::graph::DependencyDirection::Forward)
+        .filter(|pkg| !pkg.in_workspace())
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use guppy::MetadataCommand;
+
+    fn get_test_super_package_generator() -> SuperPackageGenerator {
+        SuperPackageGenerator::new().unwrap()
+    }
+
+    #[test]
+    fn test_super_toml_empty_package() {
+        let super_package = get_test_super_package_generator();
+        super_package.setup_empty_package().unwrap();
+
+        let graph = MetadataCommand::new()
+            .manifest_path(&super_package.dir.path().join("Cargo.toml"))
+            .build_graph()
+            .unwrap();
+        assert!(get_direct_dependencies(&graph).is_empty());
+    }
+}

--- a/depdive/src/super_toml.rs
+++ b/depdive/src/super_toml.rs
@@ -3,9 +3,10 @@
 //! TODO: This module can work as a stand-alone crate; isolate and publish
 
 use anyhow::Result;
+use camino::Utf8Path;
 use guppy::graph::{PackageGraph, PackageMetadata};
 use indoc::indoc;
-use std::fs::{create_dir_all, File};
+use std::fs::{copy, create_dir_all, File};
 use std::io::Write;
 use tempfile::{tempdir, TempDir};
 
@@ -22,9 +23,24 @@ impl SuperPackageGenerator {
         Ok(Self { dir: tempdir()? })
     }
 
-    pub fn get_super_package_directory(&self) -> Result<&TempDir> {
+    pub fn get_super_package_directory(&self, graph: &PackageGraph) -> Result<&TempDir> {
         self.setup_empty_package()?;
+
+        // See if the manifest path has an associated Cargo.lock
+        self.copy_cargo_lock_if_exists(graph.workspace().root())?;
+
         Ok(&self.dir)
+    }
+
+    fn copy_cargo_lock_if_exists(&self, workspace_path: &Utf8Path) -> Result<()> {
+        if workspace_path.exists() {
+            let workspace_lock_path = workspace_path.join("Cargo.lock");
+            if workspace_lock_path.exists() {
+                // Copy the lock file to super package lock file
+                copy(&workspace_lock_path, &self.dir.path().join("Cargo.lock"))?;
+            }
+        }
+        Ok(())
     }
 
     fn setup_empty_package(&self) -> Result<()> {
@@ -73,9 +89,14 @@ fn get_direct_dependencies(graph: &PackageGraph) -> Vec<PackageMetadata> {
 mod test {
     use super::*;
     use guppy::MetadataCommand;
+    use std::io::{BufRead, BufReader};
 
     fn get_test_super_package_generator() -> SuperPackageGenerator {
         SuperPackageGenerator::new().unwrap()
+    }
+
+    fn get_graph_whackadep() -> PackageGraph {
+        MetadataCommand::new().build_graph().unwrap()
     }
 
     #[test]
@@ -87,6 +108,20 @@ mod test {
             .manifest_path(&super_package.dir.path().join("Cargo.toml"))
             .build_graph()
             .unwrap();
-        assert!(get_direct_dependencies(&graph).is_empty());
+        assert_eq!(get_direct_dependencies(&graph).len(), 0);
+    }
+
+    #[test]
+    fn test_super_toml_copy_cargo_lock() {
+        let graph = get_graph_whackadep();
+        let super_package = get_test_super_package_generator();
+        super_package
+            .copy_cargo_lock_if_exists(graph.workspace().root())
+            .unwrap();
+
+
+        let super_lock = read_to_string(super_package.dir.path().join("Cargo.lock")).unwrap();
+        let lock = read_to_string(graph.workspace().root().join("Cargo.lock")).unwrap();
+        assert!(super_lock.eq(&lock));
     }
 }


### PR DESCRIPTION
As Cargo geiger can not work on workspace tomls aka virtual manifests, we create a super package with a `Cargo.toml` replicating all direct deps of workspace and a copied `Cargo.lock` to replicate the workspace's dependency graph and pass it to cargo geiger.

This change would minimize the time required to run cargo geiger on workspaces. Previously, we were running the tool individually on all member packages. 