### PR TITLE
compare version diff from crates.io code rather than git source in update review

### DIFF
--- a/depdive/src/diff.rs
+++ b/depdive/src/diff.rs
@@ -115,8 +115,7 @@ impl DiffAnalyzer {
         };
 
         //Setup a git repository for crates.io hosted source code
-        let crate_source_path = self.get_cratesio_version(&name, &version)?;
-        let crate_repo = self.init_git(&crate_source_path)?;
+        let crate_repo = self.get_git_repo_for_cratesio_version(&name, &version)?;
         let crate_repo_head = crate_repo.head()?.peel_to_commit()?;
         let cratesio_tree = crate_repo_head.tree()?;
 
@@ -194,6 +193,15 @@ impl DiffAnalyzer {
                 file_diff_stats: Some(file_diff_stats),
             }
         })
+    }
+
+    pub(crate) fn get_git_repo_for_cratesio_version(
+        &self,
+        name: &str,
+        version: &str,
+    ) -> Result<Repository> {
+        let path = self.get_cratesio_version(&name, &version)?;
+        self.init_git(&path)
     }
 
     fn get_cratesio_version(&self, name: &str, version: &str) -> Result<PathBuf> {
@@ -501,6 +509,48 @@ impl DiffAnalyzer {
             diff,
         })
     }
+
+    // This method takes two local repositories as input,
+    //     Presumably two different versions of the same code base initiated in different repos
+    //     For example, when comparing code for two versions of a crate hosted on crates.io;
+    // and returns VersionDiffInfo between the heads of the two repositories
+    pub(crate) fn get_version_diff_info_between_repos<'a>(
+        &'a self,
+        repo_version_a: &'a Repository,
+        repo_version_b: &Repository,
+    ) -> Result<VersionDiffInfo<'a>> {
+        let version_a_commit = repo_version_a.head()?.peel_to_commit()?;
+        let version_a_tree = version_a_commit.tree()?;
+
+        // make repo_b a branch of repo_a
+        let head_b = repo_version_b.head()?.peel_to_commit()?;
+        self.setup_remote(
+            &repo_version_a,
+            &repo_version_b
+                .path()
+                .to_str()
+                .ok_or_else(|| anyhow!("no local path found for repository"))?
+                .to_string(),
+            &head_b.id().to_string(),
+        )?;
+
+        // Get head commit for repo_b branch on repo_a
+        let version_b_commit = repo_version_a.find_commit(head_b.id())?;
+        let version_b_tree = version_b_commit.tree()?;
+
+        let diff = repo_version_a.diff_tree_to_tree(
+            Some(&version_a_tree),
+            Some(&version_b_tree),
+            Some(&mut DiffOptions::new()),
+        )?;
+
+        Ok(VersionDiffInfo {
+            repo: &repo_version_a,
+            commit_a: version_a_commit.id(),
+            commit_b: version_b_commit.id(),
+            diff,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -726,6 +776,31 @@ mod test {
         assert_eq!(diff.stats().unwrap().files_changed(), 6);
         assert_eq!(diff.stats().unwrap().insertions(), 199);
         assert_eq!(diff.stats().unwrap().deletions(), 82);
+    }
+
+    #[test]
+    #[serial]
+    fn test_diff_version_diff_from_crates_io() {
+        let diff_analyzer = get_test_diff_analyzer();
+        let name = "guppy";
+        let version_a = "0.8.0";
+        let version_b = "0.9.0";
+
+        let repo_a = diff_analyzer
+            .get_git_repo_for_cratesio_version(&name, &version_a)
+            .unwrap();
+        let repo_b = diff_analyzer
+            .get_git_repo_for_cratesio_version(&name, &version_b)
+            .unwrap();
+
+        let version_diff_info = diff_analyzer
+            .get_version_diff_info_between_repos(&repo_a, &repo_b)
+            .unwrap();
+
+        let diff = version_diff_info.diff;
+        assert_eq!(diff.stats().unwrap().files_changed(), 9);
+        assert_eq!(diff.stats().unwrap().insertions(), 244);
+        assert_eq!(diff.stats().unwrap().deletions(), 179);
     }
 
     #[test]

--- a/depdive/src/update.rs
+++ b/depdive/src/update.rs
@@ -80,6 +80,7 @@ pub struct VersionChangeInfo {
 #[derive(Debug, Clone)]
 pub struct VersionDiffStats {
     pub files_changed: u64,
+    pub rust_files_changed: u64,
     pub insertions: u64,
     pub deletions: u64,
     pub modified_build_scripts: HashSet<String>, // Empty indicates no change in build scripts
@@ -551,6 +552,7 @@ impl UpdateAnalyzer {
 
         Ok(VersionDiffStats {
             files_changed: stats.files_changed() as u64,
+            rust_files_changed: files_unsafe_change_stats.len() as u64,
             insertions: stats.insertions() as u64,
             deletions: stats.deletions() as u64,
             modified_build_scripts,
@@ -910,6 +912,7 @@ mod test {
                     Version::parse("0.9.0").unwrap()
                 );
                 assert_eq!(report.diff_stats.as_ref().unwrap().files_changed, 9);
+                assert_eq!(report.diff_stats.as_ref().unwrap().rust_files_changed, 4);
                 assert_eq!(report.diff_stats.as_ref().unwrap().insertions, 244);
                 assert_eq!(report.diff_stats.as_ref().unwrap().deletions, 179);
                 assert!(report
@@ -960,6 +963,7 @@ mod test {
                     report.updated_version.downloads
                 );
                 assert_eq!(report.diff_stats.as_ref().unwrap().files_changed, 78);
+                assert_eq!(report.diff_stats.as_ref().unwrap().rust_files_changed, 73);
                 assert_eq!(report.diff_stats.as_ref().unwrap().insertions, 1333);
                 assert_eq!(report.diff_stats.as_ref().unwrap().deletions, 4942);
                 assert_eq!(


### PR DESCRIPTION
# Motivation

In update review, we present a diff analysis between two version of a given crate. Analyzing the diff by downloading code from crates.io for respective versions is a reliable way rather than checking out the two versions from its git source and analyzing diff from there, which fails at cases: i) ii) when the source repository is not present or it is not a git repository, ii) when we can't figure out the head commit for a given version, iii) when the repository contains files that are ignored in crates.io code but we also then count them in our diff, e.g., `libc-test` files in `libc` crate.

Therefore, getting diff directly from crates.io code will give a reliable analysis in dependency update review report. In case of packages not hosted on crates.io, we still make use of repository diff as before.

# Improvement TODOs

for both versions, `Enum guppy::graph::summaries::SummarySource` gives the source from where the crate has been pulled from. Incorporate that information while fetching source code for a more accurate analysis in all the cases. However, this shall be part of a larger change scope in depdive where we could identify any type of versioning change in a dep, e.g., updating to a certain commit to another from git source. Currently depdive is designed around the notion of updating from one version to another for crates hosted on crates.io. #106 