### PR TITLE
Improve error handling in dependency metrics

### DIFF
--- a/depdive/src/code.rs
+++ b/depdive/src/code.rs
@@ -383,7 +383,10 @@ impl CodeAnalyzer {
             .output()?;
 
         if !output.status.success() {
-            return Err(anyhow!("Error in running cargo geiger"));
+            return Err(anyhow!(
+                "Error in running cargo geiger: \n{}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
         }
 
         let geiger_report: GeigerReport = serde_json::from_slice(&output.stdout)?;

--- a/depdive/src/diff.rs
+++ b/depdive/src/diff.rs
@@ -179,9 +179,6 @@ impl DiffAnalyzer {
             Some(&mut DiffOptions::new()),
         )?;
 
-        // Uncomment while testing
-        // self.display_diff(&diff)?;
-
         let file_diff_stats = self.get_crate_source_file_diff_report(&diff)?;
 
         Ok({
@@ -218,7 +215,7 @@ impl DiffAnalyzer {
         self.download_file(&download_path, &dest_file)
     }
 
-    pub fn get_git_repo(&self, name: &str, url: &str) -> Result<Repository> {
+    pub(crate) fn get_git_repo(&self, name: &str, url: &str) -> Result<Repository> {
         let dest_file = format!("{}-source", name);
         let dest_path = self.dir.path().join(&dest_file);
         let repo = Repository::clone(url, dest_path)?;
@@ -405,19 +402,6 @@ impl DiffAnalyzer {
         let tree = repo.find_tree(tree)?;
         Ok(tree)
     }
-
-    // fn display_diff(&self, diff: &Diff) -> Result<()> {
-    //     let stats = diff.stats()?;
-    //     let mut format = git2::DiffStatsFormat::NONE;
-    //     format |= git2::DiffStatsFormat::FULL;
-    //     let buf = stats.to_buf(format, 80)?;
-    //     print!(
-    //         "difference between crates.io and source is:\n {}",
-    //         std::str::from_utf8(&*buf).unwrap()
-    //     );
-
-    //     Ok(())
-    // }
 
     fn get_crate_source_file_diff_report(&self, diff: &Diff) -> Result<FileDiffStats> {
         let mut files_added: HashSet<String> = HashSet::new();

--- a/depdive/src/guppy_wrapper.rs
+++ b/depdive/src/guppy_wrapper.rs
@@ -1,4 +1,8 @@
-use guppy::graph::{PackageGraph, PackageMetadata};
+use anyhow::Result;
+use guppy::graph::{DependencyDirection, PackageGraph, PackageMetadata};
+use guppy::PackageId;
+use std::collections::{HashMap, HashSet};
+use std::iter;
 
 pub(crate) fn get_direct_dependencies(graph: &PackageGraph) -> Vec<PackageMetadata> {
     graph
@@ -19,4 +23,80 @@ pub(crate) fn get_all_dependencies(graph: &PackageGraph) -> Vec<PackageMetadata>
         .packages(guppy::graph::DependencyDirection::Forward)
         .filter(|pkg| !pkg.in_workspace())
         .collect()
+}
+
+pub(crate) fn get_package_dependencies<'a>(
+    graph: &'a PackageGraph,
+    package: &PackageMetadata,
+) -> Result<Vec<PackageMetadata<'a>>> {
+    let dependencies: Vec<PackageMetadata> = graph
+        .query_forward(iter::once(package.id()))?
+        .resolve()
+        .packages(DependencyDirection::Forward)
+        .filter(|pkg| pkg.id() != package.id())
+        .collect();
+    Ok(dependencies)
+}
+
+pub(crate) fn filter_exclusive_deps<'a>(
+    package: &'a PackageMetadata,
+    pacakge_dependencies: &[PackageMetadata<'a>],
+) -> Vec<PackageMetadata<'a>> {
+    // HashSet for quick lookup in dependency subtree
+    let mut package_deps: HashSet<&PackageId> =
+        pacakge_dependencies.iter().map(|dep| dep.id()).collect();
+    // Add root to the tree
+    package_deps.insert(package.id());
+
+    // Keep track of non-exclusive deps
+    let mut common_deps: HashSet<&PackageId> = HashSet::new();
+    // and exclusive ones for
+    let mut exclusive_deps: HashMap<&PackageId, PackageMetadata> = HashMap::new();
+
+    for dep in pacakge_dependencies {
+        let mut unique = true;
+        for link in dep.reverse_direct_links() {
+            let from_id = link.from().id();
+            if !package_deps.contains(from_id) || common_deps.contains(from_id) {
+                unique = false;
+                common_deps.insert(dep.id());
+                break;
+            }
+        }
+        if unique {
+            exclusive_deps.insert(dep.id(), *dep);
+        }
+    }
+
+    exclusive_deps.values().cloned().collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use guppy::CargoMetadata;
+
+    #[test]
+    fn test_guppy_wrapper_exclusive_deps() {
+        let metadata = CargoMetadata::parse_json(include_str!(
+            "../resources/test/exclusive_dep_cargo_metadata.json"
+        ))
+        .unwrap();
+        let graph = metadata.build_graph().unwrap();
+        let total_dependencies = get_all_dependencies(&graph).len();
+
+        let package = graph.packages().find(|p| p.name() == "gitlab").unwrap();
+        let dependencies = get_package_dependencies(&graph, &package).unwrap();
+        let gitlab_exclusive_deps = filter_exclusive_deps(&package, &dependencies).len();
+        let common_deps = dependencies.len() - gitlab_exclusive_deps;
+
+        let package = graph.packages().find(|p| p.name() == "octocrab").unwrap();
+        let dependencies = get_package_dependencies(&graph, &package).unwrap();
+        let octocrab_exclusive_deps = filter_exclusive_deps(&package, &dependencies).len();
+
+        assert_eq!(
+            total_dependencies,
+            common_deps + gitlab_exclusive_deps + octocrab_exclusive_deps + 2
+        );
+    }
 }

--- a/depdive/src/lib.rs
+++ b/depdive/src/lib.rs
@@ -34,8 +34,8 @@ pub struct PackageMetrics {
     // Usage and Activity metrics for a crate
     pub name: String,
     pub is_direct: bool,
-    pub cratesio_metrics: CratesioReport,
-    pub github_metrics: GitHubReport,
+    pub cratesio_metrics: Option<CratesioReport>,
+    pub github_metrics: Option<GitHubReport>,
 }
 
 pub struct DependencyAnalyzer;
@@ -65,10 +65,11 @@ impl DependencyAnalyzer {
             }
 
             let cratesio_metrics = cratesio::CratesioAnalyzer::new()?;
-            let cratesio_metrics = cratesio_metrics.analyze_cratesio(dep)?;
+            let cratesio_metrics: Option<CratesioReport> =
+                cratesio_metrics.analyze_cratesio(dep).ok();
 
             let github_metrics = github::GitHubAnalyzer::new()?;
-            let github_metrics = github_metrics.analyze_github(dep)?;
+            let github_metrics: Option<GitHubReport> = github_metrics.analyze_github(dep).ok();
 
             output.push(PackageMetrics {
                 name: dep.name().to_string(),

--- a/depdive/src/lib.rs
+++ b/depdive/src/lib.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 mod advisory;
 mod code;
 mod cratesio;
-mod diff;
+pub mod diff;
 pub mod ghcomment;
 mod github;
 mod guppy_wrapper;


### PR DESCRIPTION
# Changes made

1. Handle API rate limit in GitHub
2. When Package-metrics for a single dep fails, don't panick, instead continue with the other deps
3. moved all guppy related code to `guppy_wrapper`