### PR TITLE
Speed up tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,7 @@ dependencies = [
  "git2",
  "guppy",
  "indoc",
+ "once_cell",
  "regex",
  "reqwest",
  "rustsec",

--- a/depdive/Cargo.toml
+++ b/depdive/Cargo.toml
@@ -23,7 +23,6 @@ rustsec = "0.24.1" # RUSTSEC advisory stuff
 crates_io_api = "0.7.1" # crates.io stuff
 tokei = "12.1.2" # loc count
 camino = "1.0.4" # UTF-8 path stuff
-serial_test = "0.5.1" # avoiding running some tests in parallel
 tar = "0.4.35" # tar file stuff
 flate2 = "1.0.20" # compression/decompression
 thiserror = "1.0.26"
@@ -34,3 +33,7 @@ twox-hash = "1.6.0"
 separator = "0.4.1" # number formatting with comma
 structopt = "0.3.22"
 walkdir = "2.3.2"
+
+[dev-dependencies]
+serial_test = "0.5.1" # avoiding running some tests in parallel
+once_cell = "1.8.0"

--- a/depdive/src/advisory.rs
+++ b/depdive/src/advisory.rs
@@ -1,12 +1,15 @@
 //! This module abstracts interaction with rustsec advisory
 
 use anyhow::Result;
+use git2::Repository;
+use rustsec::repository::git::DEFAULT_URL;
 use rustsec::{
     advisory::Advisory,
     database::{Database, Query},
     package::Name,
 };
 use std::str::FromStr;
+use tempfile::tempdir;
 
 pub struct AdvisoryLookup {
     db: Database,
@@ -14,9 +17,12 @@ pub struct AdvisoryLookup {
 
 impl AdvisoryLookup {
     pub fn new() -> Result<Self> {
-        Ok(Self {
-            db: Database::fetch()?,
-        })
+        let dir = tempdir()?;
+        let dest_path = dir.path().join("rustsec");
+        Repository::clone(DEFAULT_URL, &dest_path)?;
+        let db = Database::open(&dest_path)?;
+
+        Ok(Self { db })
     }
 
     pub fn get_crate_version_advisories(

--- a/depdive/src/advisory.rs
+++ b/depdive/src/advisory.rs
@@ -34,29 +34,27 @@ impl AdvisoryLookup {
 #[cfg(test)]
 mod test {
     use super::*;
+    use once_cell::sync::Lazy;
     use rustsec::advisory::id::Id;
 
-    fn get_adivsory_lookup() -> AdvisoryLookup {
-        AdvisoryLookup::new().unwrap()
-    }
+    static ADVISORY_LOOKUP: Lazy<AdvisoryLookup> = Lazy::new(|| AdvisoryLookup::new().unwrap());
 
     #[test]
-    #[ignore] // testing set up of advisory is being implicitly done by other test(s)
     fn test_advisory_lookup() {
-        let lookup = get_adivsory_lookup();
-        let advisory = lookup.db.get(&Id::from_str("RUSTSEC-2016-0005").unwrap());
+        let advisory = ADVISORY_LOOKUP
+            .db
+            .get(&Id::from_str("RUSTSEC-2016-0005").unwrap());
         assert!(advisory.is_some());
     }
 
     #[test]
     fn test_advisory_crate_version_lookup() {
-        let lookup = get_adivsory_lookup();
-        let advisories = lookup
+        let advisories = ADVISORY_LOOKUP
             .get_crate_version_advisories("tokio", "1.7.1")
             .unwrap();
         assert!(!advisories.is_empty());
 
-        let advisories = lookup
+        let advisories = ADVISORY_LOOKUP
             .get_crate_version_advisories("::invalid::", "1.7.1")
             .unwrap();
         assert!(advisories.is_empty());

--- a/depdive/src/diff.rs
+++ b/depdive/src/diff.rs
@@ -492,7 +492,7 @@ impl DiffAnalyzer {
         })
     }
 
-    pub(crate) fn get_version_diff_info<'a>(
+    pub(crate) fn get_git_source_version_diff_info<'a>(
         &'a self,
         name: &str,
         repo: &'a Repository,
@@ -803,7 +803,7 @@ mod test {
 
         let repo = DIFF_ANALYZER.get_git_repo(name, repository).unwrap();
         let version_diff_info = DIFF_ANALYZER
-            .get_version_diff_info(
+            .get_git_source_version_diff_info(
                 name,
                 &repo,
                 &Version::parse("0.8.0").unwrap(),
@@ -861,7 +861,7 @@ mod test {
 
         let repo = DIFF_ANALYZER.get_git_repo(name, repository).unwrap();
         let diff = DIFF_ANALYZER
-            .get_version_diff_info(
+            .get_git_source_version_diff_info(
                 name,
                 &repo,
                 &Version::parse("0.0.0").unwrap(),

--- a/depdive/src/diff.rs
+++ b/depdive/src/diff.rs
@@ -623,10 +623,10 @@ mod test {
 
     #[test]
     #[serial]
-    fn test_diff_crate_source() {
+    fn test_diff_crate_source_diff_analyzer_setup() {
         let diff_analyzer = get_test_diff_analyzer();
-        let name = "libc";
-        let version = "0.2.97";
+        let name = "syn";
+        let version = "0.15.44";
         let path = diff_analyzer.get_cratesio_version(name, version).unwrap();
         assert!(path.exists());
 
@@ -636,8 +636,8 @@ mod test {
         assert!(commit.is_ok());
 
         // Add git repo as a remote to crate repo
-        let url = "https://github.com/rust-lang/libc";
-        let fetch_commit = "1c66799b7b8b82269c6bff0eab97d1a30e37fd36";
+        let url = "https://github.com/dtolnay/syn";
+        let fetch_commit = "6d798b63c255e90b7b1dbbfb3707fdce1704a18d";
         diff_analyzer
             .setup_remote(&repo, url, fetch_commit)
             .unwrap();

--- a/depdive/src/diff.rs
+++ b/depdive/src/diff.rs
@@ -605,8 +605,8 @@ mod test {
     #[test]
     fn test_diff_download_file() {
         let diff_analyzer = get_test_diff_analyzer();
-        let name = "libc";
-        let version = "0.2.97";
+        let name = "criterion-cpu-time";
+        let version = "0.1.0";
         let path = diff_analyzer
             .download_file(
                 format!(
@@ -646,12 +646,11 @@ mod test {
     #[serial]
     fn test_diff_git_repo() {
         let diff_analyzer = get_test_diff_analyzer();
-        let name = "libc";
-        let url = "https://github.com/rust-lang/libc";
+        let name = "criterion-cpu-time";
+        let url = "https://github.com/YangKeao/criterion-cpu-time";
         let repo = diff_analyzer.get_git_repo(name, url).unwrap();
         assert!(repo.workdir().is_some());
         assert!(repo.path().exists());
-        // TODO add tests for non-git repos
     }
 
     #[test]

--- a/depdive/src/diff.rs
+++ b/depdive/src/diff.rs
@@ -579,17 +579,18 @@ impl DiffAnalyzer {
 mod test {
     use super::*;
     use guppy::{graph::PackageGraph, MetadataCommand};
+    use once_cell::sync::Lazy;
     use serial_test::serial;
 
-    fn get_test_diff_analyzer() -> DiffAnalyzer {
-        DiffAnalyzer::new().unwrap()
-    }
-
-    fn get_test_graph() -> PackageGraph {
+    static GRAPH_VALID_DEP: Lazy<PackageGraph> = Lazy::new(|| {
         MetadataCommand::new()
             .current_dir(PathBuf::from("resources/test/valid_dep"))
             .build_graph()
             .unwrap()
+    });
+
+    fn get_test_diff_analyzer() -> DiffAnalyzer {
+        DiffAnalyzer::new().unwrap()
     }
 
     #[test]
@@ -741,7 +742,7 @@ mod test {
     #[test]
     #[serial]
     fn test_diff_crate_source_diff_analyzer() {
-        let graph = get_test_graph();
+        let graph = &GRAPH_VALID_DEP;
         for package in graph.packages() {
             if package.name() == "guppy" || package.name() == "octocrab" {
                 println!("testing {}, {}", package.name(), package.version());

--- a/depdive/src/update.rs
+++ b/depdive/src/update.rs
@@ -536,7 +536,7 @@ impl UpdateAnalyzer {
                 // Get version diff info from git source if avaialbe
                 // We take here the repo for the new version as the latest source
                 let repo = diff_analyzer.get_git_repo(name, repository)?;
-                let version_diff_info = match diff_analyzer.get_version_diff_info(
+                let version_diff_info = match diff_analyzer.get_git_source_version_diff_info(
                     name,
                     &repo,
                     old_version,
@@ -1151,7 +1151,7 @@ mod test {
         let repo = diff_analyzer.get_git_repo(name, repository).unwrap();
 
         let version_diff_info = diff_analyzer
-            .get_version_diff_info(
+            .get_git_source_version_diff_info(
                 name,
                 &repo,
                 &Version::parse("2.0.0").unwrap(),
@@ -1180,7 +1180,7 @@ mod test {
         assert_eq!(file.unsafe_delta.expressions, 0);
 
         let version_diff_info = diff_analyzer
-            .get_version_diff_info(
+            .get_git_source_version_diff_info(
                 name,
                 &repo,
                 &Version::parse("2.1.0").unwrap(),
@@ -1211,7 +1211,7 @@ mod test {
         assert_eq!(file.unsafe_delta.expressions, 2);
 
         let version_diff_info = diff_analyzer
-            .get_version_diff_info(
+            .get_git_source_version_diff_info(
                 name,
                 &repo,
                 &Version::parse("2.4.0").unwrap(),
@@ -1241,7 +1241,7 @@ mod test {
         let repo = diff_analyzer.get_git_repo(name, repository).unwrap();
 
         let version_diff_info = diff_analyzer
-            .get_version_diff_info(
+            .get_git_source_version_diff_info(
                 name,
                 &repo,
                 &Version::parse("2.6.0").unwrap(),


### PR DESCRIPTION
The tests would take ~45 mins before,
now it takes ~15 mins.

Integration tests in `lib` module takes a lot of time. We may ignore to some of them to speed up even more. 

Closes #88 