### PR TITLE
Add error when github token is missing

### DIFF
--- a/depdive/README.md
+++ b/depdive/README.md
@@ -23,7 +23,7 @@ i) and their version updates, to aid in security review
 When used as a CLI tool, you can run `depdive update-review commits <repo-path> <commit_a> <commit_b>` or `depdive update-review paths <path_a> <path_b>`.
 
 2. **Dependency monitoring metrics**: You can provide the path of your Cargo project and get the dependency monitoring metrics in `json` format. Check impls of `DependencyAnalyzer` and `DependencyGraphAnalyzer` at the library root.
-When used as a CLI tool, you can run `depdive dep-review package-metrics <path>` and `depdive dep-review code-metrics <path>` to get usage and activity metrics and code and unsafe analysis metrics respectively. Note that, code-mterics use [`cargo-geiger`](https://github.com/rust-secure-code/cargo-geiger) which cannot be run more than once at a time.
+When used as a CLI tool, you can run `GITHUB_TOKEN=<pat> depdive dep-review package-metrics <path>` and `depdive dep-review code-metrics <path>` to get usage and activity metrics and code and unsafe analysis metrics respectively. Note that, code-mterics use [`cargo-geiger`](https://github.com/rust-secure-code/cargo-geiger) which cannot be run more than once at a time.
 
 
 ## Dependency Update Review

--- a/depdive/src/github.rs
+++ b/depdive/src/github.rs
@@ -1,6 +1,6 @@
 //! This module abstracts the communication with GitHub API for a given crate
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Duration, FixedOffset, Utc};
 use guppy::graph::PackageMetadata;
 use reqwest::blocking::Response;
@@ -120,7 +120,8 @@ impl GitHubAnalyzer {
         let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT, HeaderValue::from_static("diem/whackadep"));
 
-        let pat = std::env::var("GITHUB_TOKEN")?;
+        let pat = std::env::var("GITHUB_TOKEN")
+            .with_context(|| format!("GITHUB_TOKEN needs to be present in env"))?;
         let pat = format!("token {}", pat);
         let mut auth_value = HeaderValue::from_str(&pat)?;
         auth_value.set_sensitive(true);

--- a/depdive/src/lib.rs
+++ b/depdive/src/lib.rs
@@ -71,16 +71,16 @@ pub struct DependencyAnalyzer;
 
 impl DependencyAnalyzer {
     /// Given a cargo project path, outputs usage and activity metrics
-    pub fn get_dep_pacakge_metrics_in_json_from_path(
+    pub fn get_dep_package_metrics_in_json_from_path(
         path: &Path,
         only_direct: bool,
     ) -> Result<String> {
         let graph = MetadataCommand::new().current_dir(path).build_graph()?;
-        Self::get_dep_pacakge_metrics_in_json(&graph, only_direct)
+        Self::get_dep_package_metrics_in_json(&graph, only_direct)
     }
 
     /// Given a guppy graph, outputs usage and activity metrics
-    fn get_dep_pacakge_metrics_in_json(graph: &PackageGraph, only_direct: bool) -> Result<String> {
+    fn get_dep_package_metrics_in_json(graph: &PackageGraph, only_direct: bool) -> Result<String> {
         let mut output: Vec<PackageMetrics> = Vec::new();
 
         let all_deps = get_all_dependencies(graph);

--- a/depdive/src/main.rs
+++ b/depdive/src/main.rs
@@ -93,7 +93,7 @@ fn update_analyzer_from_repo_commits(
 }
 
 fn get_package_metrics_for_deps_in_json(path: &str, only_direct: Option<bool>) -> Result<()> {
-    let report = DependencyAnalyzer::get_dep_pacakge_metrics_in_json_from_path(
+    let report = DependencyAnalyzer::get_dep_package_metrics_in_json_from_path(
         Path::new(path),
         only_direct.unwrap_or(false),
     )?;


### PR DESCRIPTION
When GITHUB_TOKEN is not in the execution environment, the command:
`depdive dep-review package-metrics .` fails with the error:
`Error: environment variable not found`

Commit adds context to the error bubbled up from `std::env::var`