### PR TITLE
Fix broken tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crates-index"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad4af5c8dd9940a497ef4473e6e558b660a4a1b6e5ce2cb9d85454e2aaaf947"
+dependencies = [
+ "git2",
+ "glob",
+ "hex",
+ "home",
+ "memchr",
+ "semver 1.0.3",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smartstring",
+]
+
+[[package]]
 name = "crates_io_api"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,7 +570,7 @@ dependencies = [
  "once_cell",
  "regex",
  "reqwest",
- "rustsec",
+ "rustsec 0.25.1",
  "semver 0.11.0",
  "separator",
  "serde",
@@ -1593,7 +1611,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rust-crypto",
- "rustsec",
+ "rustsec 0.24.1",
  "semver 0.11.0",
  "serde",
  "serde_json",
@@ -2063,6 +2081,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "platforms"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,17 +2481,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedb4f4352e056a699c88cfd0dde0dece944ea8f52081f8403292d22b8fd4a97"
 dependencies = [
  "cargo-lock",
- "crates-index",
+ "crates-index 0.16.7",
  "cvss",
  "fs-err",
  "git2",
  "home",
  "humantime",
  "humantime-serde",
- "platforms",
+ "platforms 1.1.0",
  "semver 1.0.3",
  "serde",
  "smol_str",
+ "thiserror",
+ "toml",
+ "url",
+]
+
+[[package]]
+name = "rustsec"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6136976fbabcd3ca37a12ae8ecc3408e8d7a94916d1cabdabd86aa4464e0887"
+dependencies = [
+ "cargo-lock",
+ "crates-index 0.17.0",
+ "cvss",
+ "fs-err",
+ "git2",
+ "home",
+ "humantime",
+ "humantime-serde",
+ "platforms 2.0.0",
+ "semver 1.0.3",
+ "serde",
  "thiserror",
  "toml",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,9 +960,9 @@ checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "git2"
-version = "0.13.20"
+version = "0.13.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
 dependencies = [
  "bitflags",
  "libc",
@@ -1462,9 +1462,9 @@ checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.21+1.1.0"
+version = "0.12.26+1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
 dependencies = [
  "cc",
  "libc",

--- a/depdive/Cargo.toml
+++ b/depdive/Cargo.toml
@@ -32,7 +32,7 @@ chrono = "0.4" # used for datetime of mongodb document
 guppy = { version = "0.9.0", features = ["summaries"] } # library to analyze deps
 semver = "0.11.0" # semver of dependencies
 url = "2.2.2" # url parsing
-rustsec = "0.24.1" # RUSTSEC advisory stuff
+rustsec = "0.25.1" # RUSTSEC advisory stuff
 crates_io_api = "0.7.1" # crates.io stuff
 tokei = "12.1.2" # loc count
 camino = "1.0.4" # UTF-8 path stuff

--- a/depdive/README.md
+++ b/depdive/README.md
@@ -7,34 +7,34 @@
 Depdive is a Rust dependency analysis tool,
 that provides various analysis metrics for
 i) Rust crates to aid in dependency selection and monitoring,
-i) and their version updates, to aid in security review
+ii) and their version updates, to aid in security review
 (e.g., for pull requests created by dependabot).
 
 
 # Installation
 
-1. You can use depdive as a Rust crate in your project that provides individual access to all the analysis offered.
+1. You can use depdive as a Rust crate in your project and have individual access to all the analyses offered.
 2. You can also use the CLI tool through `cargo install depdive`.
-3. For dependency update review, depdive outputs a markdown formatted string. Therefore, you can integrate depdive into your CI tooling to automatically get depdive comments on PR that updates a dependency. [See this example](https://github.com/diem/diem/blob/main/.github/workflows/dep-update-review.yml).
+3. For dependency update review, depdive outputs a markdown formatted string. Therefore, you can integrate depdive into your CI tooling to automatically get depdive comments on PRs that update a dependency. [See this example](https://github.com/diem/diem/blob/main/.github/workflows/dep-update-review.yml).
 
 # Usage
 
-1. **Dependency update review**: You can provide two commits for a given repo, or two paths for a repo checked out at two different commits in order to compare the dependencies that have been upgraded between the two commits and get depdive review report for those updates in markdown format. Check functions `run_update_analyzer_from_repo_commits` and `run_update_analyzer_from_paths` at the library root.
+1. **Dependency update review**: You can provide two commits for a given repo, or two paths for a repo checked out at two different commits in order to compare the dependencies that have been upgraded (between the two commits). Check functions `run_update_analyzer_from_repo_commits` and `run_update_analyzer_from_paths` at the library root.
 When used as a CLI tool, you can run `depdive update-review commits <repo-path> <commit_a> <commit_b>` or `depdive update-review paths <path_a> <path_b>`.
 
-2. **Dependency monitoring metrics**: You can provide the path of your Cargo project and get the dependency monitoring metrics in `json` format. Check impls of `DependencyAnalyzer` and `DependencyGraphAnalyzer` at the library root.
-When used as a CLI tool, you can run `GITHUB_TOKEN=<pat> depdive dep-review package-metrics <path>` and `depdive dep-review code-metrics <path>` to get usage and activity metrics and code and unsafe analysis metrics respectively. Note that, code-mterics use [`cargo-geiger`](https://github.com/rust-secure-code/cargo-geiger) which cannot be run more than once at a time.
+2. **Dependency monitoring metrics**: You can provide the path of your Cargo project and get the dependency monitoring metrics in a `json` file. Check impls of `DependencyAnalyzer` and `DependencyGraphAnalyzer` at the library root.
+When used as a CLI tool, you can run `GITHUB_TOKEN=<pat> depdive dep-review package-metrics <path>` and `depdive dep-review code-metrics <path>` to get usage and activity metrics and code and unsafe analysis metrics respectively. Note that, code-metrics use [`cargo-geiger`](https://github.com/rust-secure-code/cargo-geiger), which cannot be run more than once in parallel.
 
 
 ## Dependency Update Review
 
-Depdive offers below analysis for a Rust dependency update:
+Depdive offers the below analyses for a Rust dependency update:
 
-1. Presence of known advisories
-2. Change in build script files
-3. Change in unsafe files
-4. If code hosted on crates.io differs from the git source
-5. Version diff summary, list of changed files.
+1. Presence of known advisories;
+2. Change in build script files;
+3. Change in files with unsafe Rust;
+4. If code hosted on crates.io differs from the git source;
+5. Version diff summary and a list of changed files.
 
 The markdown comment looks like this with i) a table with checkboxes for four criteria, and ii) details available on a click.
 ![image](https://user-images.githubusercontent.com/31052507/128957013-6dc01a2b-6a13-4692-8c0c-c6951c92e4f3.png)
@@ -44,15 +44,15 @@ The markdown comment looks like this with i) a table with checkboxes for four cr
 
 Depdive offers below analysis for dependency selection/monitoring:
 
-1. **Usage metrics**: Crates.io downloads, dependents; GitHub stars, subscribers, forks.
-2. **Activity metrics**: Days since last commit, last opened issue; no. of commits, issues in last six months; no. of open issues with `bug`, `security` label.
-3. **Code analysis**: Total lines of code (LOC), total LOC pulled in through its own deps; Total LOC pulled in through exclusive deps - deps only introduced transitively by this one; if the crate has build script; how many of its deps have build script.
-4. **Unsafe analysis**: Depdive uses [`cargo-geiger`](https://github.com/rust-secure-code/cargo-geiger) to provide count of unsafe code in a Rust crate, and also total unsafe code pulled in by a crate through its dependencies.
+1. **Usage metrics**: Crates.io downloads; dependents; GitHub stars; subscribers; forks.
+2. **Activity metrics**: Days since the last commit, the last opened issue; no. of commits, issues in the last six months; no. of open issues with `bug` or `security` label.
+3. **Code analysis**: Total lines of code (LOC); total LOC pulled in through its own deps; Total LOC pulled in through exclusive deps - deps only introduced transitively by this one; if the crate has build script; how many of its deps have build script.
+4. **Unsafe analysis**: Depdive uses [`cargo-geiger`](https://github.com/rust-secure-code/cargo-geiger) to provide the count of unsafe LOC in a Rust crate, and also the count of total unsafe LOC pulled in by a crate through its dependencies.
 
 # Why care about security reviewing dependency updates?
 
-You are essentially pulling in new code to your codebase each time you make a dependency update and thus, creating a channel for security holes to sneak in. While manually reviewing dependency updates, there can be some routine checks that can be automated. The goal of depdive is to aid you in dep update review by performing such automated checks. Please, let us know what other analysis you think can be helpful.
+You are essentially pulling in new code to your codebase each time you make a dependency update, thus creating a channel for security holes to sneak in. The goal of depdive is to aid you in dep update review by performing a list of automated checks. Please, let us know what other analysis you think can be helpful.
 
 # Known issues
 
-1. Dependency update review shows if there is a change in the build script during an update. However, we only check if the crate contains a build script and the path to that build script is present in the version diff. However, the build script can call external modules and execute external code by such ways. However, we do not check if any external code potentially executed by the build script is modified or not.
+1. Dependency update review shows if there is a change in the build script during an update. We only check if the crate contains a build script and the path to that build script is present in the version diff. However, the build script can call external modules and execute external code. But we do not check if any external code potentially executed by the build script is modified or not.

--- a/depdive/src/cratesio.rs
+++ b/depdive/src/cratesio.rs
@@ -88,11 +88,7 @@ impl CratesioAnalyzer {
     }
 
     pub fn get_version_downloads(&self, crate_name: &str, version: &Version) -> Result<u64> {
-        let api_endpoint = format!(
-            "https://crates.io/api/v1/crates/{}/{}",
-            crate_name,
-            version.to_string()
-        );
+        let api_endpoint = format!("https://crates.io/api/v1/crates/{}/{}", crate_name, version);
 
         let response = self.http_client.get(api_endpoint).send()?;
         if !response.status().is_success() {

--- a/depdive/src/diff.rs
+++ b/depdive/src/diff.rs
@@ -345,7 +345,7 @@ impl DiffAnalyzer {
         }
 
         // Now we check through a series of heuristics if tag matches a version
-        let version_formatted_for_regex = version.replace(".", "\\.");
+        let version_formatted_for_regex = version.replace('.', "\\.");
         let patterns = [
             // 1. Ensure the version part does not follow any digit between 1-9,
             // e.g., to distinguish betn 0.1.8 vs 10.1.8
@@ -692,11 +692,10 @@ impl DiffAnalyzer {
         let head_b = repo_version_b.head()?.peel_to_commit()?;
         self.setup_remote(
             repo_version_a,
-            &repo_version_b
+            repo_version_b
                 .path()
                 .to_str()
-                .ok_or_else(|| anyhow!("no local path found for repository"))?
-                .to_string(),
+                .ok_or_else(|| anyhow!("no local path found for repository"))?,
             &head_b.id().to_string(),
         )?;
 

--- a/depdive/src/lib.rs
+++ b/depdive/src/lib.rs
@@ -253,7 +253,7 @@ impl UpdateAnalyzer {
             // a closure for generating hyperlink of an advisory
             let get_hyperlink = |a: &CrateVersionRustSecAdvisory| {
                 if let Some(url) = &a.url {
-                    GitHubCommentGenerator::get_hyperlink(&a.id, &url.to_string())
+                    GitHubCommentGenerator::get_hyperlink(&a.id, url.as_ref())
                 } else {
                     a.id.clone()
                 }

--- a/depdive/src/super_toml.rs
+++ b/depdive/src/super_toml.rs
@@ -458,6 +458,18 @@ mod test {
         let repo = da
             .get_git_repo("diem", "https://github.com/diem/diem.git")
             .unwrap();
+        let mut checkout_builder = CheckoutBuilder::new();
+        checkout_builder.force();
+        repo.checkout_tree(
+            &repo
+                .find_object(
+                    Oid::from_str("a116e3e75fd4f455b1ab9f5935b9f188c0baafff").unwrap(),
+                    None,
+                )
+                .unwrap(),
+            Some(&mut checkout_builder),
+        )
+        .unwrap();
         let path = repo.path().parent().unwrap();
         let graph = MetadataCommand::new()
             .current_dir(path)


### PR DESCRIPTION
1. Update `rustsec` and `git2` to fix some broken tests
2. Make changes to two tests in `super_toml` that were failing due to some crates' latest version being updated to 2021 edition
3. Fix writing in README

Also, I will open an issue on updating depdive to 2021 edition. 

@bmwill I cannot add reviewers here. Will you be able to take a look?